### PR TITLE
Add mandatory "perl" META field

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,4 +1,5 @@
 {
+    "perl"      : "6.*",
     "name"      : "bamboo",
     "version"   : "0.0.3",
     "author"   : "github:sergot",


### PR DESCRIPTION
The `perl` field specifies the minimal perl version for which this distribution can be installed and is a mandatory field. The value of `"6.*"` indicates any version suffices.

It is recommended to use [Test::META](https://modules.perl6.org/repo/Test::META) module as an author test, to catch any issues with the META file.
