### PR TITLE
`use v6` must be on the first line

### DIFF
--- a/lib/Bamboo.pm6
+++ b/lib/Bamboo.pm6
@@ -1,6 +1,6 @@
-unit class Bamboo;
-
 use v6;
+
+unit class Bamboo;
 
 use Panda;
 use Panda::App;


### PR DESCRIPTION
Upcoming rakudo releases will complain about it.